### PR TITLE
Change Anchor CLI Setup to Action

### DIFF
--- a/.github/actions/setup-anchor-cli/action.yml
+++ b/.github/actions/setup-anchor-cli/action.yml
@@ -16,7 +16,9 @@ runs:
           ./target/
         key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
     - run: cargo install anchor-cli --locked --force
+      shell: bash
     - run: chmod +x ~/.cargo/bin/anchor
+      shell: bash
     - uses: actions/upload-artifact@v2
       with:
         name: anchor-binary

--- a/.github/actions/setup-anchor-cli/action.yml
+++ b/.github/actions/setup-anchor-cli/action.yml
@@ -2,7 +2,7 @@ name: Setup Anchor CLI
 runs:
   steps:
     - uses: actions/checkout@v2
-    - uses: ../setup/
+    - uses: ./.github/actions/setup/
     - uses: actions/cache@v2
       name: Cache Cargo registry + index
       id: cache-anchor

--- a/.github/actions/setup-anchor-cli/action.yml
+++ b/.github/actions/setup-anchor-cli/action.yml
@@ -1,5 +1,6 @@
 name: Setup Anchor CLI
 runs:
+  using: composite
   steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup/

--- a/.github/actions/setup-anchor-cli/action.yml
+++ b/.github/actions/setup-anchor-cli/action.yml
@@ -1,0 +1,22 @@
+name: Setup Anchor CLI
+runs:
+  steps:
+    - uses: actions/checkout@v2
+    - uses: ../setup/
+    - uses: actions/cache@v2
+      name: Cache Cargo registry + index
+      id: cache-anchor
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          ./target/
+        key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+    - run: cargo install anchor-cli --locked --force
+    - run: chmod +x ~/.cargo/bin/anchor
+    - uses: actions/upload-artifact@v2
+      with:
+        name: anchor-binary
+        path: ~/.cargo/bin/anchor

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,7 +1,7 @@
-name: 'Setup'
-description: 'Setup'
+name: Setup
+description: Setup
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - run: sudo apt-get update && sudo apt-get install -y pkg-config build-essential libudev-dev
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  setup-anchor-cli:
+    name: Setup Anchor CLI
+    runs-on: ubuntu-18.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-anchor-cli/
+
+  build-and-test:
+    name: Build and Test
+    needs: setup-anchor-cli
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup/
+      - uses: actions/cache@v2
+        name: Cache Solana Tool Suite
+        id: cache-solana
+        with:
+          path: |
+            ~/.cache/solana/
+            ~/.local/share/solana/
+          key: solana-${{ runner.os }}-v0000-1.8.14
+      - run: sh -c "$(curl -sSfL https://release.solana.com/v1.8.14/install)"
+        shell: bash
+      - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+        shell: bash
+      - run: solana-keygen new --no-bip39-passphrase
+        shell: bash
+      - run: solana config set --url localhost
+        shell: bash
+      - uses: actions/download-artifact@v2
+        with:
+          name: anchor-binary
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/anchor
+      - run: yarn
+      - run: anchor test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+
 jobs:
   setup-anchor-cli:
     name: Setup Anchor CLI
@@ -14,8 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-anchor-cli/
 
-  build-and-test:
-    name: Build and Test
+  deploy:
+    name: Deploy to Devnet
     needs: setup-anchor-cli
     runs-on: ubuntu-20.04
     steps:
@@ -33,14 +31,4 @@ jobs:
         shell: bash
       - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
         shell: bash
-      - run: solana-keygen new --no-bip39-passphrase
-        shell: bash
-      - run: solana config set --url localhost
-        shell: bash
-      - uses: actions/download-artifact@v2
-        with:
-          name: anchor-binary
-          path: ~/.cargo/bin/
-      - run: chmod +x ~/.cargo/bin/anchor
-      - run: yarn
-      - run: anchor test
+      - run: echo "todo add more deploy steps"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,25 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/setup/
-      - uses: actions/cache@v2
-        name: Cache Cargo registry + index
-        id: cache-anchor
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./target/
-          key: cargo-${{ runner.os }}-anchor-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo install anchor-cli --locked --force
-      - run: chmod +x ~/.cargo/bin/anchor
-      - uses: actions/upload-artifact@v2
-        with:
-          name: anchor-binary
-          path: ~/.cargo/bin/anchor
+      - uses: ./.github/actions/setup-anchor-cli/
 
   build-and-test:
     name: Build and Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-anchor-cli/
 
   build-and-test:


### PR DESCRIPTION
# Summary
- Move `setup-anchor-cli` steps into a re-usable GitHub action that can be recycled in workflows
- Add some setup and a deploy workflow (skeleton only)